### PR TITLE
Remove TTY allocation from make backup_db to fix cron

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ untar_setup:
 init: untar_setup init_db collect_static
 
 backup_db:
-				docker-compose exec db mysqldump -uroot -pCAEpsilon tbpsite > tbpsite_dump_`date +%d-%m-%Y"_"%H_%M_%S`.sql
+				docker-compose exec -T db mysqldump -uroot -pCAEpsilon tbpsite > tbpsite_dump_`date +%d-%m-%Y"_"%H_%M_%S`.sql
 
 install_package:
 				docker-compose exec backend pip install $(pkg)


### PR DESCRIPTION
## Description
Simple change, so the title states it all. Could have sworn I fixed this earlier, but I probably forgot to push it, so the db backup cronjob is broken on prod again.

## Pls do 
- [x] Tested and working

## Test plan
Just running the command. Also not a new fix.
